### PR TITLE
:sparkles: Enable the dark mode support. Fixed #3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "framer-motion": "^11.11.8",
     "next": "14.2.15",
     "next-intl": "^3.21.1",
+    "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rtl-detect": "^1.1.2"

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import localFont from 'next/font/local'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, unstable_setRequestLocale } from 'next-intl/server'
 import { getLangDir } from 'rtl-detect'
+import { Providers } from './providers'
 
 const geistSans = localFont({
   src: '../fonts/GeistVF.woff',
@@ -54,9 +55,11 @@ export default async function LocaleLayout({
           geistMono.variable,
         )}
       >
-        <NextIntlClientProvider messages={messages}>
-          {children}
-        </NextIntlClientProvider>
+        <Providers themeProps={{ attribute: 'class', defaultTheme: 'system', enableColorScheme: true, enableSystem: true, children }}>
+          <NextIntlClientProvider messages={messages}>
+            {children}
+          </NextIntlClientProvider>
+        </Providers>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/[locale]/providers.tsx
+++ b/src/app/[locale]/providers.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { ThemeProviderProps } from 'next-themes/dist/types'
+import { NextUIProvider } from '@nextui-org/system'
+import { useRouter } from 'next/navigation'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import * as React from 'react'
+
+export interface ProvidersProps {
+  children: React.ReactNode
+  themeProps?: ThemeProviderProps
+}
+
+export function Providers({ children, themeProps }: ProvidersProps) {
+  const router = useRouter()
+
+  return (
+    <NextUIProvider navigate={router.push}>
+      <NextThemesProvider {...themeProps}>{children}</NextThemesProvider>
+    </NextUIProvider>
+  )
+}


### PR DESCRIPTION
I have successfully added the `next-themes` package and restructured the source code to fully support dark mode.